### PR TITLE
添加一项升级至3.x的必要修改

### DIFF
--- a/source/v3/getting-started/index.md
+++ b/source/v3/getting-started/index.md
@@ -101,6 +101,7 @@ npm i -S hexo-renderer-stylus
 
 1. 如果有 `hexo-lazyload-image` 插件，需要删除并重新安装最新版本，设置 `lazyload.isSPA: true`。
 2. 2.x 版本的 css 和 js 不适用于 3.x 版本，如果使用了 `use_cdn: true` 则需要删除。
+3. 2.x 版本的 fancybox 标签不适用于 3.x 版本，如果使用了 fancybox 标签请将其改为 gallery。
 
 
 {% p bold yellow, 建议修改 %}


### PR DESCRIPTION
升级至3.x版本后，由于原fancybox标签改名为gallery标签，因此source内使用fancybox标签的地方必须修改为gallery标签，否则无法部署